### PR TITLE
Fixes the playground to pass native strings to JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+**/*.rkt.js
+/client-out/
+/js-build/
+/node_modules/
+/out-examples/
+/out-runtime/
+/static/main.js
+/static/runtime/

--- a/app.rkt
+++ b/app.rkt
@@ -24,64 +24,64 @@
 
   (cond
     [racket-code
-     (#js.console.log "Compiling request.")
+     (#js.console.log #js"Compiling request.")
 
-     (define racks (spawn "racks"
-                            [$/array "-n"
-                                     "--js"
-                                     "--stdin"
-                                     "--enable-self-tail"]))
+     (define racks (spawn #js"racks"
+                            [$/array #js"-n"
+                                     #js"--js"
+                                     #js"--stdin"
+                                     #js"--enable-self-tail"]))
 
-     (define output (box ""))
-     (define err    (box ""))
+     (define output #js"")
+     (define err    #js"")
 
      ;; Write to process input stream, followed by closing it
      ;; so that we get output
      (#js.racks.stdin.write racket-code)
      (#js.racks.stdin.end)
 
-     (#js.racks.stdout.on "data"
+     (#js.racks.stdout.on #js"data"
        (λ (data)
-         (set-box! output (string-append (unbox output) data))))
+         ($/:= output ($/binop + output data))))
 
-     (#js.racks.stderr.on "data"
+     (#js.racks.stderr.on #js"data"
        (λ (data)
-         (set-box! err (string-append (unbox err) data))))
+         ($/:= err ($/binop + err data))))
 
-     (#js.racks.on "error"
+     (#js.racks.on #js"error"
        (λ (err)
-         (#js.res.send "Error invoking compiler.")))
+         (#js.res.send #js"Error invoking compiler.")))
 
-     (#js.racks.on "close"
+     (#js.racks.on #js"close"
        (λ (code)
          (cond
            [(zero? code)
             (#js.res.status 200)
-            (#js.res.send (unbox output))]
+            (#js.res.send output)]
            [else
             (#js.res.status 400)
-            (#js.res.send (unbox err))])))]
+            (#js.res.send err)])))]
     [else
      ($> (#js.res.status 400)
-         (send "Bad Request"))]))
+         (send #js"Bad Request"))]))
 
 ;;-----------------------------------------------------------------------------
 
 (define (main)
   (define app (express))
 
-  (#js.app.use (#js.express.static "static"))
-  (#js.app.use "/examples" (#js.express.static "examples"))
+  (#js.app.use (#js.express.static #js"static"))
+  (#js.app.use #js"/examples" (#js.express.static #js"examples"))
 
   (#js.app.use (#js.body-parser.urlencoded {$/obj [extended #f]
-                                                  [limit "8mb"]}))
-  (#js.app.use (#js.body-parser.json {$/obj [limit "8mb"]}))
+                                                  [limit #js"8mb"]}))
+  (#js.app.use (#js.body-parser.json {$/obj [limit #js"8mb"]}))
 
-  (#js.app.post "/compile" handle-compile)
+  (#js.app.post #js"/compile" handle-compile)
 
   (#js.app.listen PORT
       (λ ()
-        (#js.console.log "Starting playground at port " PORT)))
+        (#js.console.log #js"Starting playground at port" PORT)))
 
   (void))
 

--- a/client.rkt
+++ b/client.rkt
@@ -12,17 +12,17 @@
 
 (define *split-gutter-size* 3)
 
-(define *racket-editor-id*        "racket-edit")
-(define *jsout-editor-id*         "jsout-edit")
-(define *console-log-editor-id*   "console-log-edit")
+(define *racket-editor-id*        #js"racket-edit")
+(define *jsout-editor-id*         #js"jsout-edit")
+(define *console-log-editor-id*   #js"console-log-edit")
 
 ;; Gist
-(define *gist-source-file* "source.rkt")
-(define *gist-javascript-file* "compiled.js")
+(define *gist-source-file* #js"source.rkt")
+(define *gist-javascript-file* #js"compiled.js")
 
 ;; CodeMirror
 
-(define *cm-theme*          "neat")
+(define *cm-theme*          #js"neat")
 
 (define cm-editor-racket    #f)
 (define cm-editor-console   #f)
@@ -33,40 +33,39 @@
 (define compiling?           #f)
 (define last-compile-time    (#js*.Date.now))
 
-(define ++ string-append)
 (define-syntax := (make-rename-transformer #'$/:=))
 
 ;;-------------------------------------------------------------------------------
 ;; UI
 
 (define (init-split-layout!)
-  (#js*.Split [$/array "#left-container" "#right-container"]
-              {$/obj [direction    "horizontal"]
+  (#js*.Split [$/array #js"#left-container" #js"#right-container"]
+              {$/obj [direction    #js"horizontal"]
                      [sizes        [$/array 50 50]]
                      [gutterSize   *split-gutter-size*]})
-  (#js*.Split [$/array "#play-container" "#console-log-container"]
-              {$/obj [direction    "vertical"]
+  (#js*.Split [$/array #js"#play-container" #js"#console-log-container"]
+              {$/obj [direction    #js"vertical"]
                      [sizes        [$/array 75 25]]
                      [gutterSize   *split-gutter-size*]})
-  (#js*.Split [$/array "#racket-container" "#jsout-container"]
-              {$/obj [direction    "vertical"]
+  (#js*.Split [$/array #js"#racket-container" #js"#jsout-container"]
+              {$/obj [direction    #js"vertical"]
                      [sizes        [$/array 75 25]]
                      [gutterSize   *split-gutter-size*]}))
 
 (define (register-button-events!)
-  ($> (jQuery "#btn-compile")
+  ($> (jQuery #js"#btn-compile")
       (click (λ (e)
                (#js.e.preventDefault)
                (compile #f))))
-  ($> (jQuery "#btn-run")
+  ($> (jQuery #js"#btn-run")
       (click (λ (e)
                (#js.e.preventDefault)
                (run))))
-  ($> (jQuery "#btn-compile-run")
+  ($> (jQuery #js"#btn-compile-run")
       (click (λ (e)
                (#js.e.preventDefault)
                (compile #t))))
-  ($> (jQuery "#btn-save")
+  ($> (jQuery #js"#btn-save")
       (click (λ (e)
                (#js.e.preventDefault)
                (save)))))
@@ -78,57 +77,55 @@
 ;; Initialize CodeMirror in HTML TextArea of id `dom-id` and
 ;; with CodeMirror `options`
 (define (create-editor dom-id options)
-  (define options*
-    (assoc->object
-     (append options
-             `([theme          ,*cm-theme*]
-               [matchBrackets  ,#t]
-               [scrollbarStyle "simple"]
-               [extraKeys
-                ,{$/obj ["F11" (λ (cm)
+  (#js*.CodeMirror.fromTextArea
+    (#js.document.getElementById dom-id)
+    (#js*.Object.assign {$/obj} options
+      {$/obj [theme          *cm-theme*]
+             [matchBrackets  #t]
+             [scrollbarStyle #js"simple"]
+             [extraKeys
+                 {$/obj ["F11" (λ (cm)
                                  (toggle-editor-fullscreen cm))]
                         ["Esc" (λ (cm)
-                                 (when (#js.cm.getOption "fullscreen")
-                                   (toggle-editor-fullscreen cm)))]}]))))
-  (#js*.CodeMirror.fromTextArea (#js.document.getElementById dom-id)
-                                options*))
+                                 (when (#js.cm.getOption #js"fullscreen")
+                                   (toggle-editor-fullscreen cm)))]}]})))
 
 (define (toggle-editor-fullscreen cm)
-  (#js.cm.setOption "fullScreen"
-                    (not (#js.cm.getOption "fullScreen"))))
+  (#js.cm.setOption #js"fullScreen"
+                    (not (#js.cm.getOption #js"fullScreen"))))
 
 (define (init-editors!)
   (set! cm-editor-racket
         (create-editor *racket-editor-id*
-                       '([lineNumbers    #t]
-                         [mode           "scheme"])))
+                       {$/obj [lineNumbers    #t]
+                              [mode           #js"scheme"]}))
   (set! cm-editor-console
         (create-editor *console-log-editor-id*
-                       '([lineNumbers    #f]
-                         [readOnly       true])))
+                       {$/obj [lineNumbers    #f]
+                              [readOnly       #t]}))
   (set! cm-editor-jsout
         (create-editor *jsout-editor-id*
-                       '([lineNumbers    #t]
-                         [readOnly       #f]
-                         [mode           "javascript"]))))
+                       {$/obj [lineNumbers    #t]
+                              [readOnly       #f]
+                              [mode           #js"javascript"]})))
 
 (define (append-to-editor! editor str)
-  (#js.editor.replaceRange str {$/obj [line +inf.0]}))
+  (#js.editor.replaceRange (js-string str) {$/obj [line +inf.0]}))
 
 ;;-------------------------------------------------------------------------------
 ;; Console
 
 (define (get-logger level)
   (λ args
-    (append-to-editor! cm-editor-console (++ "[" level "] "))
+    (append-to-editor! cm-editor-console (string-append "[" level "] "))
     (for-each (λ (a)
                 (append-to-editor!
-                 cm-editor-console (++ (cond
+                 cm-editor-console (string-append (cond
                                          [(string? a) a]
                                          [(number? a) (number->string a)]
-                                         [else (#js*.JSON.stringify a)])
+                                         [else (racket-string (#js*.JSON.stringify a))])
                                        " "))
-                (append-to-editor! cm-editor-console "\n"))
+                (append-to-editor! cm-editor-console #js"\n"))
               args)))
 
 (define (override-console frame)
@@ -152,17 +149,17 @@
 ;; Ops
 
 (define (run-racket code)
-  (define run-frame (#js.document.getElementById "run-area"))
+  (define run-frame (#js.document.getElementById #js"run-area"))
   (define src #js.run-frame.src)
-  (:= #js.run-frame.src "")
+  (:= #js.run-frame.src #js"")
   (:= #js.run-frame.src src)
   (:= #js.run-frame.onload
       (λ ()
         (define doc #js.run-frame.contentWindow.document)
-        (define head ($ (#js.doc.getElementsByTagName "head") 0))
-        (define script (#js.doc.createElement "script"))
+        (define head (#js.doc.querySelector #js"head"))
+        (define script (#js.doc.createElement #js"script"))
         (override-console run-frame)
-        (:= #js.script.type "module")
+        (:= #js.script.type #js"module")
         (:= #js.script.text code)
         (#js.head.appendChild script)
         (#js.run-frame.contentWindow.System.loadScriptTypeModule))))
@@ -170,8 +167,8 @@
 (define (run)
   (define code (#js.cm-editor-jsout.getValue))
   (cond
-    [(equal? code "") (#js*.console.warn "Code not compiled!")]
-    [else (#js.cm-editor-console.setValue "Console Log: \n")
+    [($/binop === code #js"") (#js*.console.warn #js"Code not compiled!")]
+    [else (#js.cm-editor-console.setValue #js"Console Log: \n")
           (run-racket code)]))
 
 (define (compile execute?)
@@ -180,17 +177,17 @@
     (#js*.setTimeout (λ ()
                        (:= compiling? #f))
                      5000)
-    (#js.cm-editor-console.setValue "Console Log:\n")
-    (#js.cm-editor-jsout.setValue "Compiling ...")
-    ($> (#js.jQuery.post "/compile" {$/obj [code (#js.cm-editor-racket.getValue)]})
+    (#js.cm-editor-console.setValue #js"Console Log:\n")
+    (#js.cm-editor-jsout.setValue #js"Compiling ...")
+    ($> (#js.jQuery.post #js"/compile" {$/obj [code (#js.cm-editor-racket.getValue)]})
         (done (λ (data)
                 (set-javascript-code data)
                 (when execute?
                   (run))))
         (fail (λ (xhr status err)
                 (#js.cm-editor-console.setValue
-                 (++ "Compilation error:\n" #js.xhr.responseText))
-                (#js.cm-editor-jsout.setValue "")))
+                 ($/binop + #js"Compilation error:\n" #js.xhr.responseText))
+                (#js.cm-editor-jsout.setValue #js"")))
         (always (λ ()
                   (:= compiling? #f))))))
 
@@ -198,19 +195,19 @@
 ;; Save and Load Gist
 
 (define (load-gist id)
-  ($> (#js.jQuery.get (++ "https://api.github.com/gists/" id))
+  ($> (#js.jQuery.get ($/binop + "https://api.github.com/gists/" id))
       (done (λ (data)
               (set-racket-code ($ #js.data.files *gist-source-file* 'content))
               (define jscode ($ #js.data.files *gist-javascript-file* 'content))
               (cond
-                [(and jscode (not (equal? jscode "")))
+                [(and jscode ($/binop !== jscode #js""))
                  (set-javascript-code jscode)
                  (run)]
                 [else
                  (compile #t)])))
       (fail (λ (xhr)
               (show-error "Error load Gist"
-                          (++ #js.xhr.responseJSON.message))))))
+                          #js.xhr.responseJSON.message)))))
 
 (define (save)
   (define data
@@ -222,10 +219,10 @@
                                 [content (#js.cm-editor-racket.getValue)]}]
          [,*gist-javascript-file* ,{$/obj
                                     [content (#js.cm-editor-jsout.getValue)]}]))]})
-  ($> (#js.jQuery.post "https://api.github.com/gists" (#js*.JSON.stringify data))
+  ($> (#js.jQuery.post #js"https://api.github.com/gists" (#js*.JSON.stringify data))
       (done (λ (data)
               (define id #js.data.id)
-              (:= #js.window.location.href (++ "#gist/" id))))
+              (:= #js.window.location.href ($/binop + #js"#gist/" id))))
       (fail (λ (e)
               (show-error "Error saving as Gist"
                           #js.e.responseJSON.message)))))
@@ -233,43 +230,46 @@
 ;;-------------------------------------------------------------------------------
 
 (define (show-error title msg)
-  ($> (#js.jQuery "#error-modal")
-                  (modal "show"))
-  ($> (#js.jQuery "#error-modal .modal-title")
-      (text title))
-  ($> (#js.jQuery "#error-modal p")
-      (text msg)))
+  ($> (#js.jQuery #js"#error-modal")
+                  (modal #js"show"))
+  ($> (#js.jQuery #js"#error-modal .modal-title")
+      (text (js-string title)))
+  ($> (#js.jQuery #js"#error-modal p")
+      (text (js-string msg))))
 
 ;;-------------------------------------------------------------------------------
 
 (define (load-racket-example example-name)
-  ($> (#js.jQuery.get (format "/examples/~a.rkt" example-name))
-      (done (λ (data)
-              (set-racket-code data))))
-  ($> (#js.jQuery.get (format "/examples/~a.rkt.js" example-name))
-      (done (λ (data)
-              (set-javascript-code data)
-              (run)))))
+  (define examples #js"/examples/")
+  ($> (#js*.fetch ($> examples (concat example-name #js".rkt")))
+      (then (λ (response) (#js.response.text)))
+      (then (λ (code) (set-racket-code code))))
+  ($> (#js*.fetch ($> examples (concat example-name #js".rkt.js")))
+      (then (λ (response) (#js.response.text)))
+      (then (λ (code)
+        (set-javascript-code code)
+        (run)))))
 
 (define (reset-ui!)
   ;; Reset editors
-  (#js.cm-editor-racket.setValue "Loading ...")
-  (#js.cm-editor-jsout.setValue "")
-  (#js.cm-editor-console.setValue "")
+  (#js.cm-editor-racket.setValue #js"Loading ...")
+  (#js.cm-editor-jsout.setValue #js"")
+  (#js.cm-editor-console.setValue #js"")
 
   ;; Reset the iframe with a blank page
-  (define run-frame (#js.document.getElementById "run-area"))
-  (:= #js.run-frame.contentWindow.location "about:blank"))
+  (define run-frame (#js.document.getElementById #js"run-area"))
+  (:= #js.run-frame.contentWindow.location #js"about:blank"))
 
 (define (load-racket-code)
   ;; TODO: string-split doesn't work
-  (define parts ($> (substring #js.window.location.hash 1)
-                    (split "/")))
+  (define parts ($> (#js.window.location.hash.slice 1)
+                    (split #js"/")))
   (reset-ui!)
-  (case ($ parts 0)
+  ; TODO: #js"str" does not work in a case branch
+  (case (racket-string ($ parts 0))
     [("gist") (load-gist ($ parts 1))]
     [("example") (load-racket-example ($ parts 1))]
-    [else (load-racket-example "default")]))
+    [else (load-racket-example #js"blank")]))
 
 (define (main)
   ($> (jQuery document)
@@ -279,6 +279,6 @@
                (register-button-events!)
                (load-racket-code))))
   ($> (jQuery window)
-      (on "hashchange" load-racket-code)))
+      (on #js"hashchange" load-racket-code)))
 
 (main)

--- a/examples/blank.rkt
+++ b/examples/blank.rkt
@@ -1,8 +1,8 @@
 #lang racketscript/base
 
 (require racketscript/htdp/universe
-         racketscript/htdp/image 
+         racketscript/htdp/image
          racketscript/interop
          racketscript/browser)
 
-(#js.console.log "Hello World!")
+(displayln "Hello World!")

--- a/examples/colored-carpet.rkt
+++ b/examples/colored-carpet.rkt
@@ -12,9 +12,9 @@
   ($> (jquery document)
       (ready
        (λ ()
-         ($> (jquery "body")
-             (css "margin" 0)
-             (css "padding" 0))
+         ($> (jquery #js"body")
+             (css #js"margin" 0)
+             (css #js"padding" 0))
          (print-image (welcome-image))))))
 
 ;; (Listof Color) -> Image


### PR DESCRIPTION
Also, fixes a bug where the playground tried to evaluate .rkt.js files
prior to the compilation (because of jQuery)

Does not update all of the examples, only "colored-carpet" and "blank".