### PR TITLE
Fix Makefile to only build changed targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 **/*.rkt.js
-/client-out/
-/js-build/
 /node_modules/
-/out-examples/
-/out-runtime/
+/build
 /static/main.js
-/static/runtime/
+/static/runtime
+/static/collects
+/static/links

--- a/README.md
+++ b/README.md
@@ -16,31 +16,22 @@ file must be `source.rkt`.
   `$ROOT_URL/examples/:id.rkt` from server.
 - A `POST /compile` request will take JSON payload of format: `{
   "code": <racket-code> }` and return a compiled JS file in reponse.
-  
+
 [CoreMirror](https://codemirror.net/) is used as editor
 component. Search and Replace shortcuts
 are [here](https://codemirror.net/demo/search.html).
 
-## Installation
+## Usage
 
 After installing Racket, NodeJS, and RacketScript, execute following
-commands to install and run playground:
+commands to run the playground:
 
-	$ make fireup
+	$ make -j 4 run
 
-Or, if you wish to do it step by step:
+For development, you can use `quickrun`, after runnning `run` once,
+for building both server and client without npm install/update:
 
-    $ make setup build
-    $ make run
-
-For development, you can use:
-
-	# for building both server and client without npm install/update
-	$ make quickbuild
-
-	# for building server and client individually
-	$ make build-server
-	$ make build-client
+	$ make -j 4 quickrun
 
 ## License
 


### PR DESCRIPTION
Also, fix various weirdness such as invoking `make` from Makefile, requiring undeclared dependencies, and having a ton of .PHONY targets.

The tasks can now also be run in parallel (`make -j`).