### PR TITLE
Fix double-output and improve stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ are [here](https://codemirror.net/demo/search.html).
 After installing Racket, NodeJS, and RacketScript, execute following
 commands to run the playground:
 
-	$ make -j 4 run
+```bash
+make -j4 run
+```
 
 For development, you can use `quickrun`, after runnning `run` once,
 for building both server and client without npm install/update:
 
-	$ make -j 4 quickrun
+```bash
+make -j4 quickrun
+```
 
 ## License
 

--- a/examples/colored-carpet.rkt
+++ b/examples/colored-carpet.rkt
@@ -8,14 +8,14 @@
          racket/list
          threading)
 
+;; #js* references global JS objects.
 (let ([jquery #js*.jQuery])
-  ($> (jquery document)
-      (ready
-       (λ ()
-         ($> (jquery #js"body")
-             (css #js"margin" 0)
-             (css #js"padding" 0))
-         (print-image (welcome-image))))))
+  ;; $> chains JavaScript calls.
+  ($> (jquery #js"body")
+      ;; #js"strings" are native JavaScript strings.
+      ;; "strings" are Racket strings (sequences of Unicode codepoints).
+      (css #js"margin" 0)
+      (css #js"padding" 0)))
 
 ;; (Listof Color) -> Image
 ;; Returns a single tile of carpet
@@ -70,3 +70,5 @@
 ;; -> Non-Negative-Integet
 (define (viewport-height)
   (- ($> (#js*.jQuery window) (height)) 5))
+
+(print-image (welcome-image))

--- a/static/modules/index.html
+++ b/static/modules/index.html
@@ -12,6 +12,11 @@
   <script src="https://google.github.io/traceur-compiler/bin/BrowserSystem.js"></script>
 
   <title>Rapture Run</title>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      window.parent.postMessage('run-iframe-init', window.location.origin);
+    });
+  </script>
 </head>
 
 <body>

--- a/stub.rkt
+++ b/stub.rkt
@@ -28,6 +28,9 @@ make-list
 true
 false
 
+;; math
+pi
+
 ;; match
 (match '(1 2)
   [`(,a ,b) (+ a b)])


### PR DESCRIPTION
Instead of using `onload`, has the child frame post a message to the parent on the child's `DOMContentLoaded`.

The examples now always run after `DOMContentLoaded`.

The code is now evaluated using `System.module` instead of attaching a script, eliminating some weird error messages in the console.

Also, adds a math call to stub.rkt.

Not sure which of the above did it, but this fixes #7.