### PR TITLE
Further improve and simplify the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-**/*.rkt.js
+examples/*.rkt.js
 /node_modules/
 /build
-/static/main.js
-/static/runtime
-/static/collects
-/static/links

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,36 @@
-.PHONY: quickbuild clean run setup
+.PHONY: quickbuild quickrun run clean
 RACKS_FLAGS = --enable-self-tail --enable-flatten-if --js-beautify
-
-build: build/client build/server
-
-quickbuild: RACKS_ARGS = -n
-quickbuild: build
 
 run: build
 	node ./build/server/dist/modules/app.rkt.js
 quickrun: quickbuild
 	node ./build/server/dist/modules/app.rkt.js
 
+quickbuild: RACKS_ARGS = -n
+quickbuild: build
+
+build: build/client build/server
+
+build/server: app.rkt | node_modules
+	@echo "Compiling the server..."
+	racks $(RACKS_FLAGS) $(RACKS_ARGS) -d build/server --target babel app.rkt
 node_modules: package.json
 	npm install
+
+build/client: client.rkt | build/runtime build/examples
+	@echo "Compiling the client..."
+	racks $(RACKS_FLAGS) $(RACKS_ARGS) -d build/client client.rkt
+
+build/runtime: stub.rkt
+	@echo "Compiling the runtime..."
+	racks -d build/runtime stub.rkt
+
+build/examples: $(addsuffix .js,$(wildcard examples/*.rkt))
 examples/%.rkt.js: examples/%.rkt
 	@echo "Compiling $<..."
 	racks $(RACKS_FLAGS) -ngd build/examples $<
 	cp build/examples/modules/$*.rkt.js examples/
-build/examples: $(addsuffix .js,$(filter-out examples/default.rkt,\
-$(wildcard examples/*.rkt)))
-
-static/main.js: client.rkt
-	@echo "Compiling the client..."
-	racks $(RACKS_FLAGS) $(RACKS_ARGS) -d build/client client.rkt
-	cp build/client/dist/compiled.js static/main.js
-build/runtime: stub.rkt
-	racks -d build/runtime stub.rkt
-static/runtime: | build/runtime
-	ln -sf ../build/runtime/runtime static/runtime
-static/links: | build/runtime
-	ln -sf ../build/runtime/links static/links
-static/collects: | build/runtime
-	ln -sf ../build/runtime/collects static/collects
-build/client: build/examples static/main.js node_modules | static/runtime static/links static/collects
-
-build/server: app.rkt
-	@echo "Compiling the server..."
-	racks $(RACKS_FLAGS) $(RACKS_ARGS) -d build/server --target babel app.rkt
 
 clean:
-	rm -f static/runtime static/links static/collects
-	rm -rf build/ **/*.rkt.js static/main.js
+	rm -rf build/ examples/*.rkt.js
 

--- a/client.rkt
+++ b/client.rkt
@@ -264,7 +264,11 @@
   (case (racket-string ($ parts 0))
     [("gist") (load-gist ($ parts 1))]
     [("example") (load-racket-example ($ parts 1))]
-    [else (load-racket-example #js"blank")]))
+    [else
+      (let ([first-example
+             ($ ($> (#js.document.querySelector #js"#example-menu a") hash
+                    (split #js"/")) 1)])
+        (load-racket-example first-example))]))
 
 (define (main)
   (#js*.document.addEventListener #js"DOMContentLoaded"

--- a/examples/default.rkt
+++ b/examples/default.rkt
@@ -1,1 +1,0 @@
-colored-carpet.rkt

--- a/static/collects
+++ b/static/collects
@@ -1,0 +1,1 @@
+../build/runtime/collects

--- a/static/index.html
+++ b/static/index.html
@@ -71,9 +71,8 @@
 	<ul class="nav navbar-nav navbar-left">
 	  <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Examples <span class="caret"></span></a>
 	    <ul class="dropdown-menu" id="example-menu">
-	      <li><a href="#example/default">Default</a></li>
-	      <li><a href="#example/blank">Blank</a></li>
 	      <li><a href="#example/colored-carpet">Colored Carpet</a></li>
+	      <li><a href="#example/blank">Blank</a></li>
 	      <li><a href="#example/overview">Overview</a></li>
 	      <li><a href="#example/factorial">Factorial</a></li>
 	      <li><a href="#example/quicksort">Quicksort</a></li>

--- a/static/links
+++ b/static/links
@@ -1,0 +1,1 @@
+../build/runtime/links

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,1 @@
+../build/client/dist/compiled.js

--- a/static/runtime
+++ b/static/runtime
@@ -1,0 +1,1 @@
+../build/runtime/runtime


### PR DESCRIPTION
1. Keep symlinks in the repo instead of building them.
2. Correctly specify order-only prerequisites for build/server and build/client.
3. Remove `examples/default.rkt` edge case handling
   Instead, handle the default example selection in the client, where the first item in the list is now selected. This is better for the UI as well (the item selected by default should always be the first one).